### PR TITLE
Removes default name, adds onInit hook

### DIFF
--- a/generator/component/temp.js
+++ b/generator/component/temp.js
@@ -8,7 +8,9 @@ const <%= nameCamelCase %>Component = {
   controller: function() {
     'ngInject';
 
-    this.name = '<%= name %>';
+    this.$onInit = () => {
+      //bindings available here
+    };
   },
   controllerAs: 'vm'
 };

--- a/generator/component/temp.scss
+++ b/generator/component/temp.scss
@@ -2,4 +2,5 @@
 @import "<%= scssPath %>core/mixins";
 
 <%= name %> {
+  display: block; //or flex
 }

--- a/generator/route/temp.js
+++ b/generator/route/temp.js
@@ -6,7 +6,9 @@ import './<%= name %>.scss';
 const controller = function() {
   'ngInject';
 
-  this.name = '<%= name %>';
+  this.$onInit = () => {
+    //bindings available here
+  };
 };
 
 const <%= name %>Component = {

--- a/generator/route/temp.scss
+++ b/generator/route/temp.scss
@@ -2,4 +2,5 @@
 @import "<%= scssPath %>core/mixins";
 
 <%= name %> {
+  display: block; //or flex
 }


### PR DESCRIPTION
+ People forget entry point and place where bindings are available inside component.
   Instead of component name - add $onInit hook to components
   _(Essential after angular 1.6)_


+ adds default css **display** prop to route / component. _(Prevents situation where your component don't have any size in browsers inspector)_